### PR TITLE
Create member archives

### DIFF
--- a/interpro7dw/interpro/ftp/iprscan.py
+++ b/interpro7dw/interpro/ftp/iprscan.py
@@ -289,9 +289,9 @@ def _export_entries(cur: oracledb.Cursor, entries_file: Path, database_file: Pat
         json.dump(databases, fh)
 
 
-def build_member_archive(member: str, version: str, outdir: str, data_dir: str,
+def build_member_archive(member: str, version: str, outdir: Path, data_dir: Path,
                         pkg_func: Callable[[Path, str, tarfile.TarFile], None]):
-    member_output = Path(outdir) / f"{member}-{version}.tar.gz"
+    member_output = outdir / f"{member}-{version}.tar.gz"
     with tarfile.open(str(member_output), "w:gz") as member_tar:
         pkg_func(data_dir, version, member_tar)
 

--- a/interpro7dw/interpro/ftp/iprscan.py
+++ b/interpro7dw/interpro/ftp/iprscan.py
@@ -284,7 +284,6 @@ def _export_entries(cur: oracledb.Cursor, entries_file: Path, database_file: Pat
         json.dump(entries, fh)
 
     databases = {n: v for _, n, v in databases.values()}
-    databases["InterPro"] = ipr_version
     with database_file.open("wt") as fh:
         json.dump(databases, fh)
 


### PR DESCRIPTION
[Jira](https://www.ebi.ac.uk/panda/jira/browse/IBU-11639) - To enable selective downloading of member databases data sets from the FTP this PR adds creating an individual archive per member db (in addition to the total interpro archive used in current production pipelines and iprscan 5).