### PR TITLE
Export PIRSR matches

### DIFF
--- a/interpro7dw/interpro/ftp/uniparc.py
+++ b/interpro7dw/interpro/ftp/uniparc.py
@@ -69,6 +69,12 @@ def write_xml(bspath: str, xmlpath: str):
                 protein_elem.setAttribute("crc64", protein["crc64"])
 
                 for match in protein["matches"]:
+                    """PIRSR matches do not represent 'real' family/domain hits, so
+                    these matches should not be exported alongside the other member db matches
+                    """
+                    if match["signature"]["signatureLibraryRelease"]["name"] == "PIRSR":
+                        continue
+
                     signature = match["signature"]
                     database = signature["signatureLibraryRelease"]
 

--- a/interpro7dw/interpro/ftp/uniparc.py
+++ b/interpro7dw/interpro/ftp/uniparc.py
@@ -72,7 +72,7 @@ def write_xml(bspath: str, xmlpath: str):
                     """PIRSR matches do not represent 'real' family/domain hits, so
                     these matches should not be exported alongside the other member db matches
                     """
-                    if match["signature"]["signatureLibraryRelease"]["name"] == "PIRSR":
+                    if match["signature"]["signatureLibraryRelease"]["library"] == "PIRSR":
                         continue
 
                     signature = match["signature"]

--- a/interpro7dw/interpro/oracle/uniparc.py
+++ b/interpro7dw/interpro/oracle/uniparc.py
@@ -132,7 +132,6 @@ def export_matches(uri: str, inqueue: Queue, outqueue: Queue):
 
                 start = min(batch_proteins.keys())
                 stop = max(batch_proteins.keys())
-                print(f"start {start} stop {stop}")
 
                 # Get matches for proteins with UPI between `start` and `stop`
                 matches = get_matches(cur, start, stop, entries, signatures,
@@ -146,7 +145,6 @@ def export_matches(uri: str, inqueue: Queue, outqueue: Queue):
 
                 for upi, protein in batch_proteins.items():
                     protein["matches"] = matches.pop(upi, [])
-                    print(protein)
                 bs.write(batch_proteins)
 
         cur.close()

--- a/interpro7dw/interpro/oracle/uniparc.py
+++ b/interpro7dw/interpro/oracle/uniparc.py
@@ -185,7 +185,16 @@ def get_matches(cur: oracledb.Cursor,
         try:
             match = matches[key]
         except KeyError:
-            signature = signatures[signature_acc]
+            if signature_acc.startswith("PIRSR"):
+                signature = {
+                    "short_name": signature_acc,
+                    "name": None,
+                    "type": "Region",
+                    "entry": None,
+                }
+            else:
+                signature = signatures[signature_acc]
+
             entry_acc = signature["entry"]
             if entry_acc:
                 entry = {
@@ -251,7 +260,11 @@ def get_matches(cur: oracledb.Cursor,
           - location.motifNumber: stored in hmm_length 
           - location.pvalue: stored in dom_evalue
           - match.graphscan: stored in seq_feature
-         
+
+        PIRSR:
+          - PIRSR matches are not stored anyhere and code would break when trying to retrieve
+            signature data from the METHOD and FEATURE_METHOD table, so manually build a sig
+
         PROSITE patterns
           - location.cigarAlignment: stored in seq_feature
           

--- a/interpro7dw/interpro/oracle/uniparc.py
+++ b/interpro7dw/interpro/oracle/uniparc.py
@@ -132,6 +132,7 @@ def export_matches(uri: str, inqueue: Queue, outqueue: Queue):
 
                 start = min(batch_proteins.keys())
                 stop = max(batch_proteins.keys())
+                print(f"start {start} stop {stop}")
 
                 # Get matches for proteins with UPI between `start` and `stop`
                 matches = get_matches(cur, start, stop, entries, signatures,
@@ -145,7 +146,7 @@ def export_matches(uri: str, inqueue: Queue, outqueue: Queue):
 
                 for upi, protein in batch_proteins.items():
                     protein["matches"] = matches.pop(upi, [])
-
+                    print(protein)
                 bs.write(batch_proteins)
 
         cur.close()


### PR DESCRIPTION
[Jira](https://www.ebi.ac.uk/panda/jira/browse/IBU-11648) - Update the pipeline to handle PIRSR matches. This includes handling the lack of signature data in the `METHOD` and `FEATURE_METHOD` tables and ensures PIRSR matches are not written to the XML with other 'real' family/domain matches.