### PR TITLE
InterProScan 6 data archives

### DIFF
--- a/interpro7dw/cli.py
+++ b/interpro7dw/cli.py
@@ -437,7 +437,8 @@ def gen_tasks(config: dict) -> list[Task]:
         # InterProScan data files
         Task(
             fn=interpro.ftp.iprscan.package_data,
-            args=(ipr_pro_uri, goa_uri, data_src_dir, release_version, data_dir),
+            args=(ipr_pro_uri, goa_uri, data_src_dir, release_version,
+                  os.path.join(data_dir, "interproscan")),
             name="export-interproscan-data",
             requires=["export-entry2xrefs"],
             scheduler=dict(type=scheduler, queue=queue, mem=4000, hours=6),

--- a/interpro7dw/interpro/ftp/iprscan.py
+++ b/interpro7dw/interpro/ftp/iprscan.py
@@ -55,6 +55,16 @@ def package_data(
     logger.info("Creating InterPro archive")
     create_archive("interpro", ipr_version, outdir, outdir, pkg_interpro)
 
+    for file in [
+        pathways_file,
+        entry2pathways_file,
+        go_terms_file,
+        entry2go_terms_file,
+        entries_file,
+        databases_file,
+    ]:
+        file.unlink()
+
     data_dir = Path(data_dir)
 
     logger.info("Creating AntiFam archive")
@@ -97,9 +107,7 @@ def package_data(
     create_archive("smart", versions["smart"], data_dir, outdir, pkg_smart)
 
     logger.info("Creating SUPERFAMILY archive")
-    create_archive(
-        "superfamily", versions["ssf"], data_dir, outdir, pkg_superfamily
-    )
+    create_archive("superfamily", versions["ssf"], data_dir, outdir, pkg_superfamily)
 
     logger.info("Done")
 
@@ -301,12 +309,13 @@ def pkg_interpro(root: Path, version: str, tar: tarfile.TarFile):
         "goterms.json",
         "goterms.ipr.json",
         "entries.json",
-        "database.json"
+        "database.json",
     ]
 
     for member in members:
         path = root / member
         tar.add(path, arcname=f"interpro/{version}/{path.name}")
+
 
 def pkg_ncbifam(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "ncbifam" / version / "ncbifam.hmm"

--- a/interpro7dw/interpro/ftp/iprscan.py
+++ b/interpro7dw/interpro/ftp/iprscan.py
@@ -53,61 +53,51 @@ def package_data(
     con.close()
 
     logger.info("Creating InterPro archive")
-    output = Path(outdir) / "interpro" / f"{ipr_version}.tar.gz"
-    with tarfile.open(str(output), "w:gz") as tar:
-        for file in [
-            pathways_file,
-            entry2pathways_file,
-            go_terms_file,
-            entry2go_terms_file,
-            entries_file,
-            databases_file,
-        ]:
-            tar.add(file, arcname=f"interpro/{ipr_version}/{file.name}")
+    create_archive("interpro", ipr_version, outdir, outdir, pkg_interpro)
 
     data_dir = Path(data_dir)
 
     logger.info("Creating AntiFam archive")
-    build_member_archive("antifam", versions["antifam"], data_dir, outdir, pkg_antifam)
+    create_archive("antifam", versions["antifam"], data_dir, outdir, pkg_antifam)
 
     logger.info("Creating CATH (Gene3D + FunFam) archive")
-    build_member_archive("cath", versions["cathgene3d"], data_dir, outdir, pkg_cath)
+    create_archive("cath", versions["cathgene3d"], data_dir, outdir, pkg_cath)
 
     logger.info("Creating CDD archive")
-    build_member_archive("cdd", versions["cdd"], data_dir, outdir, pkg_cdd)
+    create_archive("cdd", versions["cdd"], data_dir, outdir, pkg_cdd)
 
     logger.info("Creating HAMAP archive")
-    build_member_archive("hamap", versions["hamap"], data_dir, outdir, pkg_hamap)
+    create_archive("hamap", versions["hamap"], data_dir, outdir, pkg_hamap)
 
     logger.info("Creating NCBIfam archive")
-    build_member_archive("ncbifam", versions["ncbifam"], data_dir, outdir, pkg_ncbifam)
+    create_archive("ncbifam", versions["ncbifam"], data_dir, outdir, pkg_ncbifam)
 
     logger.info("Creating PANTHER archive")
-    build_member_archive("panther", versions["panther"], data_dir, outdir, pkg_panther)
+    create_archive("panther", versions["panther"], data_dir, outdir, pkg_panther)
 
     logger.info("Creating Pfam archive")
-    build_member_archive("pfam", versions["pfam"], data_dir, outdir, pkg_pfam)
+    create_archive("pfam", versions["pfam"], data_dir, outdir, pkg_pfam)
 
     logger.info("Creating PIRSF archive")
-    build_member_archive("pirsf", versions["pirsf"], data_dir, outdir, pkg_pirsf)
+    create_archive("pirsf", versions["pirsf"], data_dir, outdir, pkg_pirsf)
 
     logger.info("Creating PIRSR archive")
-    build_member_archive("pirsr", versions["pirsr"], data_dir, outdir, pkg_pirsr)
+    create_archive("pirsr", versions["pirsr"], data_dir, outdir, pkg_pirsr)
 
     logger.info("Creating PRINTS archive")
-    build_member_archive("prints", versions["prints"], data_dir, outdir, pkg_prints)
+    create_archive("prints", versions["prints"], data_dir, outdir, pkg_prints)
 
     logger.info("Creating PROSITE (Patterns + Profiles) archive")
-    build_member_archive("prosite", versions["prosite"], data_dir, outdir, pkg_prosite)
+    create_archive("prosite", versions["prosite"], data_dir, outdir, pkg_prosite)
 
     logger.info("Creating SFLD archive")
-    build_member_archive("sfld", versions["sfld"], data_dir, outdir, pkg_sfld)
+    create_archive("sfld", versions["sfld"], data_dir, outdir, pkg_sfld)
 
     logger.info("Creating SMART archive")
-    build_member_archive("smart", versions["smart"], data_dir, outdir, pkg_smart)
+    create_archive("smart", versions["smart"], data_dir, outdir, pkg_smart)
 
     logger.info("Creating SUPERFAMILY archive")
-    build_member_archive(
+    create_archive(
         "superfamily", versions["ssf"], data_dir, outdir, pkg_superfamily
     )
 
@@ -250,7 +240,7 @@ def _export_entries(cur: oracledb.Cursor, entries_file: Path, databases_file: Pa
         json.dump(databases, fh)
 
 
-def build_member_archive(
+def create_archive(
     member: str,
     version: str,
     indir: Path,
@@ -258,6 +248,7 @@ def build_member_archive(
     fn: Callable[[Path, str, tarfile.TarFile], None],
 ):
     output = outdir / member / f"{member}-{version}.tar.gz"
+    output.parent.mkdir(parents=True, exist_ok=True)
     with tarfile.open(str(output), "w:gz") as tar:
         fn(indir, version, tar)
 
@@ -302,6 +293,20 @@ def pkg_hamap(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "hamap" / version / "profiles"
     tar.add(path, arcname=f"hamap/{version}/{path.name}")
 
+
+def pkg_interpro(root: Path, version: str, tar: tarfile.TarFile):
+    members = [
+        "pathways.json",
+        "pathways.ipr.json",
+        "goterms.json",
+        "goterms.ipr.json",
+        "entries.json",
+        "database.json"
+    ]
+
+    for member in members:
+        path = root / member
+        tar.add(path, arcname=f"interpro/{version}/{path.name}")
 
 def pkg_ncbifam(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "ncbifam" / version / "ncbifam.hmm"

--- a/interpro7dw/interpro/ftp/iprscan.py
+++ b/interpro7dw/interpro/ftp/iprscan.py
@@ -11,24 +11,34 @@ from ..oracle.entries import REPR_FAM_TYPES, REPR_FAM_DATABASES
 from interpro7dw.utils import logger
 
 
-def package_data(ipr_uri: str, goa_uri: str, data_dir: str, ipr_version: str,
-                 outdir: str):
+def package_data(
+    ipr_uri: str, goa_uri: str, data_dir: str, ipr_version: str, outdir: str
+):
+    """
+    Package InterProScan data files into gzip-compressed tar archives
+    :param ipr_uri: InterPro Oracle connection string
+    :param goa_uri: GOA Oracle connection string
+    :param data_dir: Path to root directory where member database data files are stored
+    :param ipr_version: InterPro release version
+    :param outdir: Output directory for archives
+    """
     logger.info("Exporting JSON files")
     outdir = Path(outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
 
     pathways_file = outdir / "pathways.json"
     entry2pathways_file = outdir / "pathways.ipr.json"
-    terms_file = outdir / "goterms.json"
-    entry2terms_file = outdir / "goterms.ipr.json"
+    go_terms_file = outdir / "goterms.json"
+    entry2go_terms_file = outdir / "goterms.ipr.json"
     entries_file = outdir / "entries.json"
-    database_file = outdir / "database.json"
+    databases_file = outdir / "database.json"
 
     con = oracledb.connect(ipr_uri)
     cur = con.cursor()
 
     _export_pathways(cur, pathways_file, entry2pathways_file)
-    _export_go_terms(cur, goa_uri, terms_file, entry2terms_file)
-    _export_entries(cur, entries_file, database_file, ipr_version)
+    _export_go_terms(cur, goa_uri, go_terms_file, entry2go_terms_file)
+    _export_entries(cur, entries_file, databases_file)
 
     cur.execute(
         """
@@ -42,107 +52,70 @@ def package_data(ipr_uri: str, goa_uri: str, data_dir: str, ipr_version: str,
     cur.close()
     con.close()
 
-    data_dir = Path(data_dir)
-    output = Path(outdir) / "interproscan-data.tar.gz"
-    prefix = f"interproscan-data-{ipr_version}/"
-    logger.info("Building the InterPro archive")
+    logger.info("Creating InterPro archive")
+    output = Path(outdir) / "interpro" / f"{ipr_version}.tar.gz"
     with tarfile.open(str(output), "w:gz") as tar:
-        for file in [pathways_file, entry2pathways_file, terms_file,
-                     entry2terms_file, entries_file]:
-            tar.add(file, arcname=f"{prefix}xrefs/{file.name}")
+        for file in [
+            pathways_file,
+            entry2pathways_file,
+            go_terms_file,
+            entry2go_terms_file,
+            entries_file,
+            databases_file,
+        ]:
+            tar.add(file, arcname=f"interpro/{ipr_version}/{file.name}")
 
-        logger.info("Archiving AntiFam")
-        pkg_antifam(data_dir, versions["antifam"], tar, prefix=prefix)
+    data_dir = Path(data_dir)
 
-        logger.info("Archiving CATH (Gene3D + FunFam)")
-        pkg_cath(data_dir, versions["cathgene3d"], tar, prefix=prefix)
+    logger.info("Creating AntiFam archive")
+    build_member_archive("antifam", versions["antifam"], data_dir, outdir, pkg_antifam)
 
-        logger.info("Archiving CDD")
-        pkg_cdd(data_dir, versions["cdd"], tar, prefix=prefix)
+    logger.info("Creating CATH (Gene3D + FunFam) archive")
+    build_member_archive("cath", versions["cathgene3d"], data_dir, outdir, pkg_cath)
 
-        logger.info("Archiving HAMAP")
-        pkg_hamap(data_dir, versions["hamap"], tar, prefix=prefix)
+    logger.info("Creating CDD archive")
+    build_member_archive("cdd", versions["cdd"], data_dir, outdir, pkg_cdd)
 
-        logger.info("Archiving NCBIfam")
-        pkg_ncbifam(data_dir, versions["ncbifam"], tar, prefix=prefix)
+    logger.info("Creating HAMAP archive")
+    build_member_archive("hamap", versions["hamap"], data_dir, outdir, pkg_hamap)
 
-        logger.info("Archiving PANTHER")
-        pkg_panther(data_dir, versions["panther"], tar, prefix=prefix)
+    logger.info("Creating NCBIfam archive")
+    build_member_archive("ncbifam", versions["ncbifam"], data_dir, outdir, pkg_ncbifam)
 
-        logger.info("Archiving Pfam")
-        pkg_pfam(data_dir, versions["pfam"], tar, prefix=prefix)
+    logger.info("Creating PANTHER archive")
+    build_member_archive("panther", versions["panther"], data_dir, outdir, pkg_panther)
 
-        logger.info("Archiving PIRSF")
-        pkg_pirsf(data_dir, versions["pirsf"], tar, prefix=prefix)
+    logger.info("Creating Pfam archive")
+    build_member_archive("pfam", versions["pfam"], data_dir, outdir, pkg_pfam)
 
-        logger.info("Archiving PIRSR")
-        pkg_pirsr(data_dir, versions["pirsr"], tar, prefix=prefix)
+    logger.info("Creating PIRSF archive")
+    build_member_archive("pirsf", versions["pirsf"], data_dir, outdir, pkg_pirsf)
 
-        logger.info("Archiving PRINTS")
-        pkg_prints(data_dir, versions["prints"], tar, prefix=prefix)
+    logger.info("Creating PIRSR archive")
+    build_member_archive("pirsr", versions["pirsr"], data_dir, outdir, pkg_pirsr)
 
-        logger.info("Archiving PROSITE (Patterns + Profiles)")
-        pkg_prosite(data_dir, versions["prosite"], tar, prefix=prefix)
+    logger.info("Creating PRINTS archive")
+    build_member_archive("prints", versions["prints"], data_dir, outdir, pkg_prints)
 
-        logger.info("Archiving SFLD")
-        pkg_sfld(data_dir, versions["sfld"], tar, prefix=prefix)
+    logger.info("Creating PROSITE (Patterns + Profiles) archive")
+    build_member_archive("prosite", versions["prosite"], data_dir, outdir, pkg_prosite)
 
-        logger.info("Archiving SMART")
-        pkg_smart(data_dir, versions["smart"], tar, prefix=prefix)
+    logger.info("Creating SFLD archive")
+    build_member_archive("sfld", versions["sfld"], data_dir, outdir, pkg_sfld)
 
-        logger.info("Archiving SUPERFAMILY")
-        pkg_superfamily(data_dir, versions["ssf"], tar, prefix=prefix)
+    logger.info("Creating SMART archive")
+    build_member_archive("smart", versions["smart"], data_dir, outdir, pkg_smart)
 
-    logger.info("Building InterPro Member archives")
-    logger.info("Archiving AntiFam")
-    build_member_archive("AntiFam", versions['antifam'], outdir, data_dir, pkg_antifam)
-
-    logger.info("Archiving CATH (Gene3D + FunFam)")
-    build_member_archive("Cath", versions['cathgene3d'], outdir, data_dir, pkg_cath)
-
-    logger.info("Archiving CDD")
-    build_member_archive("CDD", versions['cdd'], outdir, data_dir, pkg_cdd)
-
-    logger.info("Archiving HAMAP")
-    build_member_archive("HAMAP", versions['hamap'], outdir, data_dir, pkg_hamap)
-
-    logger.info("Archiving NCBIfam")
-    build_member_archive("NCBIfam", versions['ncbifam'], outdir, data_dir, pkg_ncbifam)
-
-    logger.info("Archiving PANTHER")
-    build_member_archive("PANTHER", versions['panther'], outdir, data_dir, pkg_panther)
-
-    logger.info("Archiving Pfam")
-    build_member_archive("Pfam", versions['pfam'], outdir, data_dir, pkg_pfam)
-
-    logger.info("Archiving PIRSF")
-    build_member_archive("PIRSF", versions['pirsf'], outdir, data_dir, pkg_pirsf)
-
-    logger.info("Archiving PIRSR")
-    build_member_archive("PIRSR", versions['pirsr'], outdir, data_dir, pkg_pirsr)
-
-    logger.info("Archiving PRINTS")
-    build_member_archive("PRINTS", versions['prints'], outdir, data_dir, pkg_prints)
-
-    logger.info("Archiving PROSITE (Patterns + Profiles)")
-    build_member_archive("PROSITE", versions['prosite'], outdir, data_dir, pkg_prosite)
-
-    logger.info("Archiving SFLD")
-    build_member_archive("SFLD", versions['sfld'], outdir, data_dir, pkg_sfld)
-
-    logger.info("Archiving SMART")
-    build_member_archive("SMART", versions['smart'], outdir, data_dir, pkg_smart)
-
-    logger.info("Archiving SUPERFAMILY")
-    build_member_archive("SUPERFAMILY", versions['ssf'], outdir, data_dir, pkg_superfamily)
+    logger.info("Creating SUPERFAMILY archive")
+    build_member_archive(
+        "superfamily", versions["ssf"], data_dir, outdir, pkg_superfamily
+    )
 
     logger.info("Done")
 
 
 def _export_pathways(
-        cur: oracledb.Cursor,
-        pathways_file: Path,
-        entry2pathways_file: Path
+    cur: oracledb.Cursor, pathways_file: Path, entry2pathways_file: Path
 ):
     cur.execute(
         """
@@ -170,10 +143,7 @@ def _export_pathways(
 
 
 def _export_go_terms(
-        cur: oracledb.Cursor,
-        goa_uri: str,
-        terms_file: Path,
-        entry2terms_file: Path
+    cur: oracledb.Cursor, goa_uri: str, terms_file: Path, entry2terms_file: Path
 ):
     version = uniprot.goa.get_timestamp(goa_uri).strftime("%Y-%m-%d")
     terms = {}
@@ -203,16 +173,13 @@ def _export_go_terms(
             interpro2go[entry_acc] = [go_id]
 
     with terms_file.open("wt") as fh:
-        json.dump({
-            "version": version,
-            "terms": terms
-        }, fh)
+        json.dump({"version": version, "terms": terms}, fh)
 
     with entry2terms_file.open("wt") as fh:
         json.dump(interpro2go, fh)
 
 
-def _export_entries(cur: oracledb.Cursor, entries_file: Path, database_file: Path, ipr_version: str):
+def _export_entries(cur: oracledb.Cursor, entries_file: Path, databases_file: Path):
     cur.execute("SELECT CODE, ABBREV FROM INTERPRO.CV_ENTRY_TYPE")
     types = dict(cur.fetchall())
 
@@ -256,12 +223,10 @@ def _export_entries(cur: oracledb.Cursor, entries_file: Path, database_file: Pat
     for row in cur.fetchall():
         dbshort, dbname, dbversion = databases[row[4]]
 
-        if (types[row[3]].lower() in REPR_DOM_TYPES and
-                dbshort in REPR_DOM_DATABASES):
+        if types[row[3]].lower() in REPR_DOM_TYPES and dbshort in REPR_DOM_DATABASES:
             repr_type = "domain"
             repr_index = REPR_DOM_DATABASES.index(dbshort)
-        elif (types[row[3]].lower() in REPR_FAM_TYPES and
-                dbshort in REPR_FAM_DATABASES):
+        elif types[row[3]].lower() in REPR_FAM_TYPES and dbshort in REPR_FAM_DATABASES:
             repr_type = "family"
             repr_index = REPR_FAM_DATABASES.index(dbshort)
         else:
@@ -273,123 +238,121 @@ def _export_entries(cur: oracledb.Cursor, entries_file: Path, database_file: Pat
             "description": row[2],
             "type": types[row[3]],
             "integrated": row[5],
-            "representative": {
-                "type": repr_type,
-                "index": repr_index
-            },
-            "database": dbname
+            "representative": {"type": repr_type, "index": repr_index},
+            "database": dbname,
         }
 
     with entries_file.open("wt") as fh:
         json.dump(entries, fh)
 
     databases = {n: v for _, n, v in databases.values()}
-    with database_file.open("wt") as fh:
+    with databases_file.open("wt") as fh:
         json.dump(databases, fh)
 
 
-def build_member_archive(member: str, version: str, outdir: Path, data_dir: Path,
-                        pkg_func: Callable[[Path, str, tarfile.TarFile], None]):
-    member_output = outdir / f"{member}-{version}.tar.gz"
-    with tarfile.open(str(member_output), "w:gz") as member_tar:
-        pkg_func(data_dir, version, member_tar)
+def build_member_archive(
+    member: str,
+    version: str,
+    indir: Path,
+    outdir: Path,
+    fn: Callable[[Path, str, tarfile.TarFile], None],
+):
+    output = outdir / member / f"{member}-{version}.tar.gz"
+    with tarfile.open(str(output), "w:gz") as tar:
+        fn(indir, version, tar)
 
 
-def pkg_antifam(root: Path, version: str, tar: tarfile.TarFile,
-                prefix: str = ""):
+def pkg_antifam(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "antifam" / version / "AntiFam.hmm"
-    tar.add(path, arcname=f"{prefix}antifam/AntiFam.hmm")
+    tar.add(path, arcname=f"antifam/{version}/AntiFam.hmm")
 
 
-def pkg_cath(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_cath(root: Path, version: str, tar: tarfile.TarFile):
     base = root / "cath-gene3d" / version
 
     path = base / "gene3d_main.hmm"
-    tar.add(path, arcname=f"{prefix}cath/gene3d/{path.name}")
+    tar.add(path, arcname=f"cath/{version}/gene3d/{path.name}")
 
     path = base / "discontinuous" / "discontinuous_regs.pkl.py3"
-    tar.add(path, arcname=f"{prefix}cath/gene3d/{path.name}")
+    tar.add(path, arcname=f"cath/{version}/gene3d/{path.name}")
 
     path = base / "model_to_family_map.tsv"
-    tar.add(path, arcname=f"{prefix}cath/gene3d/{path.name}")
+    tar.add(path, arcname=f"cath/{version}/gene3d/{path.name}")
 
     path = base / "funfam" / "models"
     for child in path.iterdir():
-        tar.add(child, arcname=f"{prefix}cath/funfam/{child.name}")
+        tar.add(child, arcname=f"cath/{version}/funfam/{child.name}")
 
 
-def pkg_cdd(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_cdd(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "cdd" / version / "data"
-    tar.add(path, arcname=f"{prefix}cdd/data")
+    tar.add(path, arcname=f"cdd/{version}/data")
 
     path = root / "cdd" / version / "db"
-    tar.add(path, arcname=f"{prefix}cdd/db")
+    tar.add(path, arcname=f"cdd/{version}/db")
 
 
-def pkg_hamap(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_hamap(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "hamap" / version / "hamap.prf"
-    tar.add(path, arcname=f"{prefix}hamap/{path.name}")
+    tar.add(path, arcname=f"hamap/{version}/{path.name}")
 
     path = root / "hamap" / version / "hamap.hmm.lib"
-    tar.add(path, arcname=f"{prefix}hamap/{path.name}")
+    tar.add(path, arcname=f"hamap/{version}/{path.name}")
 
     path = root / "hamap" / version / "profiles"
-    tar.add(path, arcname=f"{prefix}hamap/{path.name}")
+    tar.add(path, arcname=f"hamap/{version}/{path.name}")
 
 
-def pkg_ncbifam(root: Path, version: str, tar: tarfile.TarFile,
-                prefix: str = ""):
+def pkg_ncbifam(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "ncbifam" / version / "ncbifam.hmm"
-    tar.add(path, arcname=f"{prefix}ncbifam/{path.name}")
+    tar.add(path, arcname=f"ncbifam/{version}/{path.name}")
 
 
-def pkg_panther(root: Path, version: str, tar: tarfile.TarFile,
-                prefix: str = ""):
+def pkg_panther(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "panther" / version / "famhmm"
-    tar.add(path, arcname=f"{prefix}panther/{path.name}")
+    tar.add(path, arcname=f"panther/{version}/{path.name}")
 
     path = root / "panther" / version / "PAINT_Annotations"
     for child in path.iterdir():
         if child.suffix == ".json":
-            name = f"{prefix}panther/{child.parent.name}/{child.name}"
+            name = f"panther/{version}/{child.parent.name}/{child.name}"
             tar.add(child, arcname=name)
 
     path = root / "panther" / version / "Tree_MSF"
-    tar.add(path, arcname=f"{prefix}panther/{path.name}")
+    tar.add(path, arcname=f"panther/{version}/{path.name}")
 
 
-def pkg_pfam(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_pfam(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "pfam" / version / "pfam_a.hmm"
-    tar.add(path, arcname=f"{prefix}pfam/{path.name}")
+    tar.add(path, arcname=f"pfam/{version}/{path.name}")
 
     path = root / "pfam" / version / "pfam_clans"
-    tar.add(path, arcname=f"{prefix}pfam/{path.name}")
+    tar.add(path, arcname=f"pfam/{version}/{path.name}")
 
     path = root / "pfam" / version / "pfam_a.dat"
-    tar.add(path, arcname=f"{prefix}pfam/{path.name}")
+    tar.add(path, arcname=f"pfam/{version}/{path.name}")
 
     path = root / "pfam" / version / "pfam_a.seed"
-    tar.add(path, arcname=f"{prefix}pfam/{path.name}")
+    tar.add(path, arcname=f"pfam/{version}/{path.name}")
 
 
-def pkg_pirsf(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_pirsf(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "pirsf" / version / "pirsf.dat"
-    tar.add(path, arcname=f"{prefix}pirsf/{path.name}")
+    tar.add(path, arcname=f"pirsf/{version}/{path.name}")
 
     path = root / "pirsf" / version / "sf_hmm_all"
-    tar.add(path, arcname=f"{prefix}pirsf/{path.name}")
+    tar.add(path, arcname=f"pirsf/{version}/{path.name}")
 
 
-def pkg_pirsr(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_pirsr(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "pirsr" / version / "sr_hmm_all"
-    tar.add(path, arcname=f"{prefix}pirsr/{path.name}")
+    tar.add(path, arcname=f"pirsr/{version}/{path.name}")
 
     path = root / "pirsr" / version / "sr_uru.json"
-    tar.add(path, arcname=f"{prefix}pirsr/{path.name}")
+    tar.add(path, arcname=f"pirsr/{version}/{path.name}")
 
 
-def pkg_prints(root: Path, version: str, tar: tarfile.TarFile,
-               prefix: str = ""):
+def pkg_prints(root: Path, version: str, tar: tarfile.TarFile):
     members = [
         ("FingerPRINTShierarchy21Feb2012", "FingerPRINTShierarchy.db"),
         ("prints42_0.pval_blos62", "prints.pval"),
@@ -397,25 +360,24 @@ def pkg_prints(root: Path, version: str, tar: tarfile.TarFile,
 
     for src, dst in members:
         path = root / "prints" / version / src
-        tar.add(path, arcname=f"{prefix}prints/{dst}")
+        tar.add(path, arcname=f"prints/{version}/{dst}")
 
 
-def pkg_prosite(root: Path, version: str, tar: tarfile.TarFile,
-                prefix: str = ""):
+def pkg_prosite(root: Path, version: str, tar: tarfile.TarFile):
     path = root / "prosite" / version / "evaluator.dat"
-    tar.add(path, arcname=f"{prefix}prosite/{path.name}")
+    tar.add(path, arcname=f"prosite/{version}/{path.name}")
 
     path = root / "prosite" / version / "prosite_patterns.dat"
-    tar.add(path, arcname=f"{prefix}prosite/{path.name}")
+    tar.add(path, arcname=f"prosite/{version}/{path.name}")
 
     path = root / "prosite" / version / "prosite_profiles"
-    tar.add(path, arcname=f"{prefix}prosite/{path.name}")
+    tar.add(path, arcname=f"prosite/{version}/{path.name}")
 
     path = root / "prosite" / version / "skip_flagged_profiles.txt"
-    tar.add(path, arcname=f"{prefix}prosite/{path.name}")
+    tar.add(path, arcname=f"prosite/{version}/{path.name}")
 
 
-def pkg_sfld(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_sfld(root: Path, version: str, tar: tarfile.TarFile):
     members = [
         "sfld.hmm",
         "sfld_sites.annot",
@@ -424,10 +386,10 @@ def pkg_sfld(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
 
     for member in members:
         path = root / "sfld" / version / member
-        tar.add(path, arcname=f"{prefix}sfld/{path.name}")
+        tar.add(path, arcname=f"sfld/{version}/{path.name}")
 
 
-def pkg_smart(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
+def pkg_smart(root: Path, version: str, tar: tarfile.TarFile):
     members = [
         "smart.HMMs",
         "smart.HMMs.bin",
@@ -435,11 +397,10 @@ def pkg_smart(root: Path, version: str, tar: tarfile.TarFile, prefix: str = ""):
 
     for member in members:
         path = root / "smart" / version / member
-        tar.add(path, arcname=f"{prefix}smart/{path.name}")
+        tar.add(path, arcname=f"smart/{version}/{path.name}")
 
 
-def pkg_superfamily(root: Path, version: str, tar: tarfile.TarFile,
-                    prefix: str = ""):
+def pkg_superfamily(root: Path, version: str, tar: tarfile.TarFile):
     members = [
         "hmmlib_1.75",
         "hmmlib_1.75.h3f",
@@ -456,4 +417,4 @@ def pkg_superfamily(root: Path, version: str, tar: tarfile.TarFile,
 
     for member in members:
         path = root / "superfamily" / version / member
-        tar.add(path, arcname=f"{prefix}superfamily/{path.name}")
+        tar.add(path, arcname=f"superfamily/{version}/{path.name}")


### PR DESCRIPTION
This PR slightly refactor `package_data()` so it creates individual archives for each member database + InterPro, and create a "full" archive that can be used to deploy InterProScan on the cluster.

The `pkg_*` functions have been refactored so instead of taking a `TarFile` object to write to, they return the list of members to add to the archives.

Paths in the archives no include the version number, e.g. `antifam/8.0/AntiFam.hmm` instead of `antifam/AntiFam.hmm`.