### PR TITLE
Ftp site annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,15 +193,16 @@ In the following tasks, *id* represents the cluster identifier, as defined in th
 
 **Exporting files for the public FTP**
 
-| Task name             | Description                                                                                                    |
-|-----------------------|----------------------------------------------------------------------------------------------------------------|
-| export-features-xml   | Export an XML file of sequence feature matches (MobiDB-Lite, TMHMM, Phobius, Coils)                            |
-| export-flat-files     | Export flat files (list of entries, InterPro-GO mapping, protein matches, etc.)                                |
-| export-interpro-xml   | Export an XML file of InterPro entries and their annotations (e.g. abstract, member database signatures, etc.) |
-| export-matches-xml    | Export an XML file of member databases protein matches                                                         |
-| export-release-notes  | Export a text file containing the release notes                                                                |
-| export-structures-xml | Export an XML file of structural matches (PDBe, CATH, SCOP)                                                    |
-| export-uniparc-xml    | Export a `tar.gz` archive of all UniParc matches                                                               |
+| Task name               | Description                                                                                                    |
+|-------------------------|----------------------------------------------------------------------------------------------------------------|
+| export-features-xml     | Export an XML file of sequence feature matches (MobiDB-Lite, TMHMM, Phobius, Coils)                            |
+| export-flat-files       | Export flat files (list of entries, InterPro-GO mapping, protein matches, etc.)                                |
+| export-interpro-xml     | Export an XML file of InterPro entries and their annotations (e.g. abstract, member database signatures, etc.) |
+| export-matches-xml      | Export an XML file of member databases protein matches                                                         |
+| export-release-notes    | Export a text file containing the release notes                                                                |
+| export-structures-xml   | Export an XML file of structural matches (PDBe, CATH, SCOP)                                                    |
+| export-site-annotations | Export an XML file of all site annotations                                                             |
+| export-uniparc-xml      | Export a `tar.gz` archive of all UniParc matches                                                               |
 
 **Exporting files for internal use (other EMBL-EBI groups)**
 

--- a/interpro7dw/cli.py
+++ b/interpro7dw/cli.py
@@ -946,7 +946,6 @@ def gen_tasks(config: dict) -> list[Task]:
         Task(
             fn=interpro.ftp.xmlfiles.export_site_annotations,
             args=(df.protein2residues, pub_dir),
-            kwargs=dict(processes=8),
             name="ftp-site-annotations",
             requires=["export-residues"],
             scheduler=dict(type=scheduler, queue=queue, cpu=8, mem=24000, hours=20),

--- a/interpro7dw/cli.py
+++ b/interpro7dw/cli.py
@@ -943,6 +943,14 @@ def gen_tasks(config: dict) -> list[Task]:
             requires=["export-uniparc"],
             scheduler=dict(type=scheduler, queue=queue, cpu=8, mem=40000, hours=72),
         ),
+        Task(
+            fn=interpro.ftp.xmlfiles.export_site_annotations,
+            args=(df.protein2residues, pub_dir),
+            kwargs=dict(processes=8),
+            name="ftp-site-annotations",
+            requires=["export-residues"],
+            scheduler=dict(type=scheduler, queue=queue, cpu=8, mem=24000, hours=20),
+        ),
     ]
 
     tasks += ebi_files_tasks + ftp_files_tasks

--- a/interpro7dw/interpro/ftp/xmlfiles.py
+++ b/interpro7dw/interpro/ftp/xmlfiles.py
@@ -749,9 +749,9 @@ def export_site_annotations(
                     for descr, locations in entry["descriptions"].items():
                         fh.write(f'      <site description="{descr}">\n')
                         for loc in locations:
-                            start = loc["start"]
-                            end = loc["end"]
-                            residue = loc.get("residue", "")
+                            start = loc[1]
+                            end = loc[2]
+                            residue = loc[0]
                             fh.write(f'        <location start="{start}" end="{end}" residue="{residue}"/>\n')
                         fh.write(f'      </site>\n')
                     fh.write(f'    </entry>\n')


### PR DESCRIPTION
To test:
```
pip install .
interprodw-build config.toml -t ftp-site-annotations
```

~3h to run:
```
|2025-07-17 09:18:56|2025-07-17 10:19:00|2025-07-17 10:19:16|2025-07-17 15:02:00
ftp-site-annotations||1|1|0|0|2||null||2025-07-17 19:34:20: INFO: starting exporting site annotations
2025-07-17 22:33:31: INFO: done
|2025-07-17 18:33:51|2025-07-17 19:33:52|2025-07-17 19:34:20|2025-07-17 22:33:31
sqlite> .exit
[lcf@hl-codon-29-04 interpro7-dw]$ cd ..
[lcf@hl-codon-29-04 lcf]$ gunzip data/interpro/releases/106.0/site_annotations.xml.gz
```

Result in /hps/nobackup/agb/interpro/lcf/data/interpro/releases/106.0/site_annotations.xml