### PR TITLE
Filter EC numbers

### DIFF
--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -561,7 +561,7 @@ def _filter_ec_numbers(entry_enzymes: dict, entry_proteins: int) -> set[str]:
     def _are_sets_identical(sets):
         first_set = sets[0]
         return all(s == first_set for s in sets[1:])
-    
+
     if len(passing_ec) == 1:
         # If only one EC number passes, we keep it
         return set(passing_ec.keys())
@@ -575,7 +575,7 @@ def _filter_ec_numbers(entry_enzymes: dict, entry_proteins: int) -> set[str]:
         # both are protein assigned EC numbers, check if they have the same proteins
         if _are_sets_identical(list(passing_ec.values())):
             return set(passing_ec.keys())
-    
+
     else:
         # Add all EC numbers that are common stems
         final_ecs = set()
@@ -585,12 +585,12 @@ def _filter_ec_numbers(entry_enzymes: dict, entry_proteins: int) -> set[str]:
                 final_ecs.add(ecno)
             else:
                 protein_ecs.add(ecno)
-        
+
         if protein_ecs:
             # If there are protein assigned EC numbers, check if they have the same proteins
             if _are_sets_identical(list(passing_ec[ec] for ec in protein_ecs)):
                 final_ecs.update(protein_ecs)
-        
+
         return final_ecs
-    
+
     return set()

--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -199,8 +199,8 @@ def _process_entries(proteins_file: str, matches_file: str,
                 entry = xrefs[match_acc] = _init_entry_xrefs()
 
             entry["matches"] += len(match["locations"])
-            entry["proteins"].append((protein_acc, protein_id,
-                                      in_alphafold))
+            in_swissprot = protein_acc in protein2enzymes
+            entry["proteins"].append((protein_acc, protein_id, in_alphafold, in_swissprot))
 
             if taxon_id in entry["taxa"]:
                 entry["taxa"][taxon_id] += 1

--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -290,7 +290,7 @@ def export_xrefs(uniprot_uri: str, proteins_file: str, matches_file: str,
     :param tempdir: Temporary directory
     """
     logger.info("loading Swiss-Prot data")
-    protein2enzymes, no_ec_swiss_proteins = uniprot.proteins.get_swissprot2enzyme(uniprot_uri)
+    protein2enzymes = uniprot.proteins.get_swissprot2enzyme(uniprot_uri)
     protein2reactome = uniprot.proteins.get_swissprot2reactome(uniprot_uri)
 
     logger.info("iterating proteins")
@@ -467,13 +467,9 @@ def export_xrefs(uniprot_uri: str, proteins_file: str, matches_file: str,
             }
 
             # Filter EC numbers
-            num_entry_swissprots = len(
-                {acc for acc, *_ in entry_xrefs["proteins"]
-                if acc in protein2enzymes or acc in no_ec_swiss_proteins}
-            )
             entry_xrefs["enzymes"] = _filter_ec_numbers(
                 entry_xrefs["enzymes"],
-                num_entry_swissprots
+                sum([1 for prot_tuple in entry_xrefs["proteins"] if prot_tuple[-1]])
             )
 
             # Adds MetaCyc pathways
@@ -524,74 +520,13 @@ def _format_node(node: dict) -> dict:
 
 def _filter_ec_numbers(entry_enzymes: dict, entry_proteins: int) -> set[str]:
     """Filter EC numbers to keep only those with at least three protein accessions
-    and 80% coverage of the entry proteins.
+    and 60% coverage of the entry proteins.
     """
-    passing_ec = {}
-    failing_ec = {}
+    passing_ec = set()
 
     for ecno, ecno_proteins in entry_enzymes.items():
-        if len(ecno_proteins) < 3:
-            failing_ec[ecno] = ecno_proteins
-            continue
-
         coverage = len(ecno_proteins) / entry_proteins if entry_proteins else 0
-        if coverage < 0.8:
-            failing_ec[ecno] = ecno_proteins
-        else:
-            passing_ec[ecno] = ecno_proteins
+        if len(ecno_proteins) >= 3 and coverage >= 0.6:
+            passing_ec.add(ecno)
 
-    """Identify the 3-digit common EC stems in the failed EC numbers and apply the same filtering
-    criteria to them."""
-    failed_ecs = list(failing_ec.keys())
-    stem_counts = Counter(['.'.join(ec.split('.')[:3] + '.') for ec in failed_ecs])
-    stems = [stem for stem in stem_counts if stem_counts[stem] > 1]
-    for ec_stem in stems:
-        stem_proteins = set()
-        for ecno in entry_enzymes:
-            if ecno.startswith(ec_stem):
-                stem_proteins.update(entry_enzymes[ecno])
-
-        if len(stem_proteins) < 3:
-            continue
-
-        coverage = len(stem_proteins) / entry_proteins if entry_proteins else 0
-        if coverage >= 0.8:
-            passing_ec[ec_stem] = stem_proteins
-
-    """Filter on multi-functionality. If an InterPro entry has multiple EC numbers, make sure
-    the exact same proteins are associated with each of the EC numbers."""
-    def _are_sets_identical(sets: list[set]) -> bool:
-        return all(s == sets[0] for s in sets[1:])
-
-    if len(passing_ec) == 1:
-        # If only one EC number passes, we keep it
-        return set(passing_ec.keys())
-
-    elif len(passing_ec) == 2:
-        # It could be a protein assigned EC number and its common stem - in those cases keep both
-        ec1, ec2 = list(passing_ec.keys())
-        if ec1 in stems or ec2 in stems:
-            return {ec1, ec2}
-
-        # both are protein assigned EC numbers, check if they have the same proteins
-        if _are_sets_identical(list(passing_ec.values())):
-            return {ec1, ec2}
-
-    elif len(passing_ec) >= 3:
-        # Add all EC numbers that are common stems
-        final_ecs = set()
-        protein_ecs = set()
-        for ecno in passing_ec:
-            if ecno in stems:
-                final_ecs.add(ecno)
-            else:
-                protein_ecs.add(ecno)
-
-        if protein_ecs:
-            # If there are protein assigned EC numbers, check if they have the same proteins
-            if _are_sets_identical(list(passing_ec[ec] for ec in protein_ecs)):
-                final_ecs.update(protein_ecs)
-
-        return final_ecs
-
-    return set()
+    return passing_ec

--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -199,8 +199,7 @@ def _process_entries(proteins_file: str, matches_file: str,
                 entry = xrefs[match_acc] = _init_entry_xrefs()
 
             entry["matches"] += len(match["locations"])
-            in_swissprot = protein_acc in protein2enzymes
-            entry["proteins"].append((protein_acc, protein_id, in_alphafold, in_swissprot))
+            entry["proteins"].append((protein_acc, protein_id, in_alphafold, protein["reviewed"]))
 
             if taxon_id in entry["taxa"]:
                 entry["taxa"][taxon_id] += 1

--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -576,7 +576,7 @@ def _filter_ec_numbers(entry_enzymes: dict, entry_proteins: int) -> set[str]:
         if _are_sets_identical(list(passing_ec.values())):
             return set(passing_ec.keys())
 
-    else:
+    elif len(passing_ec) >= 3:
         # Add all EC numbers that are common stems
         final_ecs = set()
         protein_ecs = set()

--- a/interpro7dw/interpro/xrefs/entries.py
+++ b/interpro7dw/interpro/xrefs/entries.py
@@ -137,7 +137,7 @@ def export_sim_entries(matches_file: str, output: str):
 def _init_entry_xrefs() -> dict:
     return {
         "dom_orgs": set(),
-        "enzymes": set(),
+        "enzymes": {},      # {"EC number": set(protein accessions)}
         "genes": set(),
         "matches": 0,
         "reactome": set(),
@@ -230,7 +230,9 @@ def _process_entries(proteins_file: str, matches_file: str,
 
             if match["database"].lower() == "interpro":
                 for ecno in protein2enzymes.get(protein_acc, []):
-                    entry["enzymes"].add(ecno)
+                    if ecno not in entry["enzymes"]:
+                        entry["enzymes"][ecno] = set()
+                    entry["enzymes"][ecno].add(protein_acc) 
 
                 pathways = protein2reactome.get(protein_acc, [])
                 for pathway_id, pathway_name in pathways:

--- a/interpro7dw/uniprot/proteins.py
+++ b/interpro7dw/uniprot/proteins.py
@@ -1,5 +1,7 @@
 import re
 
+from collections import defaultdict
+
 import oracledb
 
 from interpro7dw.utils import logger
@@ -251,7 +253,7 @@ def get_swissprot2enzyme(url: str) -> dict[str, list[str]]:
         if subcatg == 'EC' and descr and re.match(r"(\d+\.){3}(\d+|-)$", descr):
             proteins[acc].append(descr)
         else:
-          proteins[acc] # ensure empty list is initialised
+          proteins[acc] # init empty list for marking presence in swissprot in xref.entries._process_entries
 
     cur.close()
     con.close()

--- a/interpro7dw/uniprot/proteins.py
+++ b/interpro7dw/uniprot/proteins.py
@@ -233,7 +233,7 @@ def get_swissprot2enzyme(url: str) -> dict[str, list[str]]:
   
     cur.execute(
         """
-        SELECT E.ACCESSION, C.SUBCATG_TYPE, D.DESCR
+        SELECT DISTINCT E.ACCESSION, D.DESCR
         FROM SPTR.DBENTRY E
         INNER JOIN SPTR.DBENTRY_2_DESC D
           ON E.DBENTRY_ID = D.DBENTRY_ID
@@ -247,13 +247,11 @@ def get_swissprot2enzyme(url: str) -> dict[str, list[str]]:
     )
 
     proteins = defaultdict(list)
-    for acc, subcatg, descr in cur:
+    for acc, descr in cur:
         # Accepts X.X.X.X or X.X.X.-
         # Does not accept preliminary EC numbers (e.g. X.X.X.nX)
-        if subcatg == 'EC' and descr and re.match(r"(\d+\.){3}(\d+|-)$", descr):
+        if descr and re.match(r"(\d+\.){3}(\d+|-)$", descr):
             proteins[acc].append(descr)
-        else:
-          proteins[acc] # init empty list for marking presence in swissprot in xref.entries._process_entries
 
     cur.close()
     con.close()


### PR DESCRIPTION
Re-instates a modified implementation of the EC number filtering to reduce the number of pathways assigned to each Entry.
Modifications: No longer linked to GO-terms, and applies the multi-EC number filtering to all cases of multi-EC numbers not just where there are 2, and also does not apply multi-EC filtering in cases of common EC stems.